### PR TITLE
Fix file adapter delete()

### DIFF
--- a/lib/modules/file.js
+++ b/lib/modules/file.js
@@ -110,7 +110,7 @@ module.exports = function(options) {
   function remove(file, callback) {
     var filePath = getFilePath(file);
 
-    fs.unlink(filePath, function(error) {
+    fs.unlink(path.join(uploadDir, filePath), function(error) {
       callback(error);
     });
   }


### PR DESCRIPTION
When using relative paths, the file adapter's delete/remove function would sometimes miss the file (depending the directory structure) as the upload path was missing from it.
